### PR TITLE
Plugin node functions rename

### DIFF
--- a/cio/api.py
+++ b/cio/api.py
@@ -116,8 +116,8 @@ def load(uri):
     if node:
         # Load node data with related plugin
         plugin = plugins.resolve(node.uri)  # May raise UnknownPlugin and should be handled outside api
-        data = plugin._load(node)
-        node.content = plugin._render(node, data)
+        data = plugin.load_node(node)
+        node.content = plugin.render_node(node, data)
 
     else:
         # Initialize non-existing node without version

--- a/cio/pipeline/pipes/plugin.py
+++ b/cio/pipeline/pipes/plugin.py
@@ -20,8 +20,8 @@ class PluginPipe(BasePipe):
                     node.uri
                 ))
             else:
-                data = plugin._load(node)
-                node.content = plugin._render(node, data)
+                data = plugin.load_node(node)
+                node.content = plugin.render_node(node, data)
 
         return response
 
@@ -36,7 +36,7 @@ class PluginPipe(BasePipe):
                 pass
                 # TODO: Should we maybe raise here?
             else:
-                node = plugin._save(node)
+                node = plugin.save_node(node)
 
     def set_response(self, response):
         return self.render_response(response)
@@ -49,7 +49,7 @@ class PluginPipe(BasePipe):
                 pass
                 # TODO: Should we maybe raise here?
             else:
-                node = plugin._publish(node)
+                node = plugin.publish_node(node)
 
     def publish_response(self, response):
         return self.render_response(response)
@@ -59,7 +59,7 @@ class PluginPipe(BasePipe):
             try:
                 plugin = plugins.resolve(node.uri)
                 if node.content is not empty:
-                    plugin._delete(node)
+                    plugin.delete_node(node)
             except UnknownPlugin:
                 pass
                 # TODO: Should we maybe raise here?

--- a/cio/plugins/base.py
+++ b/cio/plugins/base.py
@@ -18,7 +18,7 @@ class BasePlugin(object):
         """
         return content
 
-    def _load(self, node):
+    def load_node(self, node):
         """
         Return plugin data and modify for raw node
         """
@@ -30,14 +30,14 @@ class BasePlugin(object):
         """
         return data
 
-    def _save(self, node):
+    def save_node(self, node):
         """
         Perform action on node, persist external plugin resources and return content string for plugin data
         """
         node.content = self.save(node.content)
         return node
 
-    def _publish(self, node):
+    def publish_node(self, node):
         """
         Perform actions on publish and return node to persist
         """
@@ -49,7 +49,7 @@ class BasePlugin(object):
         """
         pass
 
-    def _delete(self, node):
+    def delete_node(self, node):
         """
         Delete external plugin resources
         """
@@ -61,7 +61,7 @@ class BasePlugin(object):
         """
         return data
 
-    def _render(self, node, data):
+    def render_node(self, node, data):
         """
         Prepares node for render and returns rendered content
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -121,11 +121,11 @@ class ReplacerPlugin(BasePlugin):
 
     ext = 'rpl'
 
-    def _load(self, node):
+    def load_node(self, node):
         node.uri = node.uri.clone(path="page/loaded.rpl")
         node.content = "REPLACED"
         return self.load(node.content)
 
-    def _render(self, node, data):
+    def render_node(self, node, data):
         node.uri = node.uri.clone(path="page/rendered.rpl")
         return self.render(data)


### PR DESCRIPTION
renames
- `_load`
- `_save`
- `_publish`
- `_delete`
- `_render` 
in `plugins/base.py` to
- `load_node`
- `save_node`
- `publish_node`
- `delete_node`
- `render_node`
respectively to prevent naming collision with image plugin in djedi-cms